### PR TITLE
Added XIAO ESP32S3 Sense pinout

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -436,6 +436,27 @@ Configuration for ESP-EYE
       name: My Camera
       # ...
 
+Configuration for XIAO ESP32S3 Sense
+------------------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera:
+      external_clock:
+        pin: GPIO10
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO40
+        scl: GPIO39
+      data_pins: [GPIO15, GPIO17, GPIO18, GPIO16, GPIO14, GPIO12, GPIO11, GPIO48]
+      vsync_pin: GPIO38
+      href_pin: GPIO47
+      pixel_clock_pin: GPIO13
+
+      # Image settings
+      name: My Camera
+      # ...
 
 See Also
 --------


### PR DESCRIPTION
based on:
https://wiki.seeedstudio.com/xiao_esp32s3_camera_usage/#camera-slot-circuit-design-for-expansion-boards

## Checklist:

  - [ x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
   
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
